### PR TITLE
Make sure that sequences emit values on MainScheduler

### DIFF
--- a/Sources/RxKeyboard.swift
+++ b/Sources/RxKeyboard.swift
@@ -50,6 +50,7 @@ public class RxKeyboard: NSObject {
     )
     let frameVariable = Variable<CGRect>(defaultFrame)
     self.frame = frameVariable.asObservable()
+      .distinctUntilChanged()
       // `ConcurrentMainScheduler` is more recommended to use with `subscribeOn` operator but
       // it's important to make sequence emit values in serial. See #13 if you wonder what happens
       // if the sequence doesn't ensure the value order.

--- a/Sources/RxKeyboard.swift
+++ b/Sources/RxKeyboard.swift
@@ -20,10 +20,16 @@ public class RxKeyboard: NSObject {
   public static let instance = RxKeyboard()
 
   /// An observable keyboard frame.
+  ///
+  /// The sequence of values will be subscribed on `MainScheduler`
+  /// (as same as `subscribeOn(MainScheduler.instance)`).
   public let frame: Observable<CGRect>
 
   /// An observable visible height of keyboard. Emits keyboard height if the keyboard is visible
   /// or `0` if the keyboard is not visible.
+  ///
+  /// The sequence of values will be subscribed on `MainScheduler`
+  /// (as same as `subscribeOn(MainScheduler.instance)`).
   public let visibleHeight: Observable<CGFloat>
 
 
@@ -44,6 +50,10 @@ public class RxKeyboard: NSObject {
     )
     let frameVariable = Variable<CGRect>(defaultFrame)
     self.frame = frameVariable.asObservable()
+      // `ConcurrentMainScheduler` is more recommended to use with `subscribeOn` operator but
+      // it's important to make sequence emit values in serial. See #13 if you wonder what happens
+      // if the sequence doesn't ensure the value order.
+      .subscribeOn(MainScheduler.instance)
     self.visibleHeight = self.frame.map { UIScreen.main.bounds.height - $0.origin.y }
 
     super.init()

--- a/Sources/RxKeyboard.swift
+++ b/Sources/RxKeyboard.swift
@@ -20,11 +20,11 @@ public class RxKeyboard: NSObject {
   public static let instance = RxKeyboard()
 
   /// An observable keyboard frame.
-  public let frame: Driver<CGRect>
+  public let frame: Observable<CGRect>
 
   /// An observable visible height of keyboard. Emits keyboard height if the keyboard is visible
   /// or `0` if the keyboard is not visible.
-  public let visibleHeight: Driver<CGFloat>
+  public let visibleHeight: Observable<CGFloat>
 
 
   // MARK: Private
@@ -43,7 +43,7 @@ public class RxKeyboard: NSObject {
       height: 0
     )
     let frameVariable = Variable<CGRect>(defaultFrame)
-    self.frame = frameVariable.asDriver()
+    self.frame = frameVariable.asObservable()
     self.visibleHeight = self.frame.map { UIScreen.main.bounds.height - $0.origin.y }
 
     super.init()


### PR DESCRIPTION
### Background

`Driver` uses `subscribeOn(ConcurrentMainScheduler.instance)` which doesn't guarantee the order of values. As you can see in the movie, the sequence emits values in wrong order when you release the keyboard after dragging it to bottom.

![rxkeyboard-bug mov](https://cloud.githubusercontent.com/assets/931655/22035215/7f0da04e-dd32-11e6-966d-65c7fbc4275a.gif)

### Workaround

* Replace `Driver` with `Observable`
* `subscribeOn(MainScheduler.instance)`
* `distinctUntilChanged()` to reduce unnecessary values
