### PR TITLE
Take only `.changed` state from pan gesture recognizer

### DIFF
--- a/Sources/RxKeyboard.swift
+++ b/Sources/RxKeyboard.swift
@@ -43,7 +43,7 @@ public class RxKeyboard: NSObject {
       height: 0
     )
     let frameVariable = Variable<CGRect>(defaultFrame)
-    self.frame = frameVariable.asDriver()
+    self.frame = frameVariable.asDriver().distinctUntilChanged()
     self.visibleHeight = self.frame.map { UIScreen.main.bounds.height - $0.origin.y }
 
     super.init()
@@ -82,7 +82,8 @@ public class RxKeyboard: NSObject {
     let didPan = self.panRecognizer.rx.event
       .withLatestFrom(frameVariable.asObservable()) { ($0, $1) }
       .flatMap { (gestureRecognizer, frame) -> Observable<CGRect> in
-        guard let window = UIApplication.shared.windows.first,
+        guard case .changed = gestureRecognizer.state,
+          let window = UIApplication.shared.windows.first,
           frame.origin.y < UIScreen.main.bounds.height
         else { return .empty() }
         let origin = gestureRecognizer.location(in: window)


### PR DESCRIPTION
Sometimes the frame value from `.ended` is emitted after the `willChangeFrame`.

![rxkeyboard-bug mov](https://cloud.githubusercontent.com/assets/931655/22035215/7f0da04e-dd32-11e6-966d-65c7fbc4275a.gif)

To prevent awkward situation, make sure that the frame value from pan recognizer take only `.changed` event.

![rxkeyboard-fix mov](https://cloud.githubusercontent.com/assets/931655/22036271/404fe2dc-dd36-11e6-9769-8e4f082992cc.gif)
