### PR TITLE
Feature/update syntax

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "ReactiveX/RxSwift" >= 3.0
+github "ReactiveX/RxSwift" >= 3.4

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "ReactiveX/RxSwift" "3.0.0"
+github "ReactiveX/RxSwift" "3.4.0"

--- a/Example/Sources/ViewControllers/MessageListViewController.swift
+++ b/Example/Sources/ViewControllers/MessageListViewController.swift
@@ -102,13 +102,13 @@ class MessageListViewController: UIViewController {
           self.view.layoutIfNeeded()
         }
       })
-      .addDisposableTo(self.disposeBag)
+      .disposed(by: self.disposeBag)
 
     RxKeyboard.instance.willShowVisibleHeight
       .drive(onNext: { keyboardVisibleHeight in
         self.collectionView.contentOffset.y += keyboardVisibleHeight
       })
-      .addDisposableTo(self.disposeBag)
+      .disposed(by: self.disposeBag)
 
     self.messageInputBar.rx.sendButtonTap
       .subscribe(onNext: { [weak self] text in
@@ -119,7 +119,7 @@ class MessageListViewController: UIViewController {
         self.collectionView.insertItems(at: [indexPath])
         self.collectionView.scrollToItem(at: indexPath, at: [], animated: true)
       })
-      .addDisposableTo(self.disposeBag)
+      .disposed(by: self.disposeBag)
   }
 
 

--- a/Example/Sources/Views/MessageInputBar.swift
+++ b/Example/Sources/Views/MessageInputBar.swift
@@ -61,8 +61,8 @@ final class MessageInputBar: UIView {
 
     self.textView.rx.text
       .map { text in text?.isEmpty == false }
-      .bindTo(self.sendButton.rx.isEnabled)
-      .addDisposableTo(self.disposeBag)
+      .bind(to: self.sendButton.rx.isEnabled)
+      .disposed(by: self.disposeBag)
   }
   
   required init?(coder aDecoder: NSCoder) {

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ RxKeyboard.instance.frame
   .drive(onNext: { frame in
     print(frame)
   })
-  .addDisposableTo(disposeBag)
+  .disposed(by: disposeBag)
 ```
 
 ## Tips and Tricks
@@ -52,7 +52,7 @@ RxKeyboard.instance.frame
       .drive(onNext: { keyboardVisibleHeight in
         scrollView.contentInset.bottom = keyboardVisibleHeight
       })
-      .addDisposableTo(disposeBag)
+      .disposed(by: disposeBag)
     ```
 
 - <a name="tip-content-offset" href="#tip-content-offset">🔗</a> **I want to adjust `UIScrollView`'s `contentOffset` to fit keyboard height.**
@@ -62,7 +62,7 @@ RxKeyboard.instance.frame
       .drive(onNext: { keyboardVisibleHeight in
         scrollView.contentInset.offset.y += keyboardVisibleHeight
       })
-      .addDisposableTo(disposeBag)
+      .disposed(by: disposeBag)
     ```
 
 - <a name="tip-toolbar" href="#tip-toolbar">🔗</a> **I want to make `UIToolbar` move along with the keyboard in an interactive dismiss mode. (Just like the wonderful GIF above!)**
@@ -74,7 +74,7 @@ RxKeyboard.instance.frame
       .drive(onNext: { keyboardVisibleHeight in
         toolbar.frame.origin.y = self.view.height - toolbar.frame.height - keyboardVisibleHeight
       })
-      .addDisposableTo(disposeBag)
+      .disposed(by: disposeBag)
     ```
 
     If you're using Auto Layout, you have to capture the toolbar's bottom constraint and set `constant` to keyboard visible height.
@@ -84,7 +84,7 @@ RxKeyboard.instance.frame
       .drive(onNext: { keyboardVisibleHeight in
         toolbarBottomConstraint.constant = -1 * keyboardVisibleHeight
       })
-      .addDisposableTo(disposeBag)
+      .disposed(by: disposeBag)
     ```
 
     > **Note**: In real world, you should use `setNeedsLayout()` and `layoutIfNeeded()` with animation block. See the [example project](https://github.com/RxSwiftCommunity/RxKeyboard/blob/master/Example/Sources/ViewControllers/MessageListViewController.swift#L92-L105) for example.
@@ -93,8 +93,8 @@ RxKeyboard.instance.frame
     
 ## Dependencies
 
-- [RxSwift](https://github.com/ReactiveX/RxSwift) (>= 3.0)
-- [RxCocoa](https://github.com/ReactiveX/RxSwift) (>= 3.0)
+- [RxSwift](https://github.com/ReactiveX/RxSwift) (>= 3.4)
+- [RxCocoa](https://github.com/ReactiveX/RxSwift) (>= 3.4)
 
 ## Requirements
 

--- a/RxKeyboard.podspec
+++ b/RxKeyboard.podspec
@@ -11,8 +11,8 @@ Pod::Spec.new do |s|
   s.frameworks       = 'UIKit', 'Foundation'
   s.requires_arc     = true
 
-  s.dependency 'RxSwift', '>= 3.0'
-  s.dependency 'RxCocoa', '>= 3.0'
+  s.dependency 'RxSwift', '>= 3.4'
+  s.dependency 'RxCocoa', '>= 3.4'
 
   s.ios.deployment_target = '8.0'
 

--- a/Sources/RxKeyboard.swift
+++ b/Sources/RxKeyboard.swift
@@ -104,8 +104,8 @@ public class RxKeyboard: NSObject {
 
     // merge into single sequence
     Observable.of(didPan, willChangeFrame, willHide).merge()
-      .bindTo(frameVariable)
-      .addDisposableTo(self.disposeBag)
+      .bind(to: frameVariable)
+      .disposed(by: self.disposeBag)
 
     // gesture recognizer
     self.panRecognizer.delegate = self
@@ -115,7 +115,7 @@ public class RxKeyboard: NSObject {
       .subscribe(onNext: { _ in
         UIApplication.shared.windows.first?.addGestureRecognizer(self.panRecognizer)
       })
-      .addDisposableTo(self.disposeBag)
+      .disposed(by: self.disposeBag)
   }
 
 }


### PR DESCRIPTION
Hi, Jeon!

`bindTo` was recently renamed to `bind(to:)` so I opened this PR to align with latest RxSwift syntax. However, I'm not sure if this can be merged because it will require RxSwift 3.4+ to work with this library. What are your thoughts on this?