### PR TITLE
Factor out interactive pan gesture to into separate subspec

### DIFF
--- a/RxKeyboard.podspec
+++ b/RxKeyboard.podspec
@@ -7,12 +7,19 @@ Pod::Spec.new do |s|
   s.author           = { 'Suyeol Jeon' => 'devxoul@gmail.com' }
   s.source           = { :git => 'https://github.com/RxSwiftCommunity/RxKeyboard.git',
                          :tag => s.version.to_s }
-  s.source_files     = 'Sources/*.swift'
   s.frameworks       = 'UIKit', 'Foundation'
   s.requires_arc     = true
 
   s.dependency 'RxSwift', '>= 3.0'
   s.dependency 'RxCocoa', '>= 3.0'
+
+  s.subspec 'Core' do |core|
+    core.source_files = 'Sources/RxKeyboard.swift'
+  end
+
+  s.subspec 'Interactive' do |interactive|
+    interactive.source_files = 'Sources/RxKeyboardInteractive.swift'
+  end
 
   s.ios.deployment_target = '8.0'
 

--- a/RxKeyboard.xcodeproj/project.pbxproj
+++ b/RxKeyboard.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		0310C6771DA9535200BDA512 /* RxKeyboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0310C6761DA9535200BDA512 /* RxKeyboard.swift */; };
 		03CE448E1E35AAE5006DD6E9 /* RxCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 034E7CA31DAD548900CFC398 /* RxCocoa.framework */; };
 		03CE448F1E35AAE5006DD6E9 /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 034E7CA41DAD548900CFC398 /* RxSwift.framework */; };
+		407629F61EB906710051197B /* RxKeyboardInteractive.swift in Sources */ = {isa = PBXBuildFile; fileRef = 407629F51EB906710051197B /* RxKeyboardInteractive.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -22,6 +23,7 @@
 		034E7CA41DAD548900CFC398 /* RxSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxSwift.framework; path = Carthage/Build/iOS/RxSwift.framework; sourceTree = "<group>"; };
 		034E7CA51DAD548900CFC398 /* RxTests.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxTests.framework; path = Carthage/Build/iOS/RxTests.framework; sourceTree = "<group>"; };
 		03A258CB1DA94EC50035A85B /* RxKeyboard.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RxKeyboard.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		407629F51EB906710051197B /* RxKeyboardInteractive.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RxKeyboardInteractive.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -42,6 +44,7 @@
 			children = (
 				0310C6711DA9525200BDA512 /* RxKeyboard.h */,
 				0310C6761DA9535200BDA512 /* RxKeyboard.swift */,
+				407629F51EB906710051197B /* RxKeyboardInteractive.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -167,6 +170,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				0310C6771DA9535200BDA512 /* RxKeyboard.swift in Sources */,
+				407629F61EB906710051197B /* RxKeyboardInteractive.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/RxKeyboardInteractive.swift
+++ b/Sources/RxKeyboardInteractive.swift
@@ -1,0 +1,24 @@
+//
+//  RxKeyboardInteractive.swift
+//  RxKeyboard
+//
+//  Created by Ian Ynda-Hummel on 5/2/17.
+//  Copyright © 2017 Suyeol Jeon. All rights reserved.
+//
+
+import UIKit
+
+import RxCocoa
+import RxSwift
+
+internal extension RxKeyboard {
+  internal func attachPanRecognizer() {
+    NotificationCenter.default.rx.notification(.UIApplicationDidFinishLaunching)
+      .map { _ in Void() }
+      .startWith(Void()) // when RxKeyboard is initialized before UIApplication.window is created
+      .subscribe(onNext: { _ in
+        UIApplication.shared.windows.first?.addGestureRecognizer(self.panRecognizer)
+      })
+      .addDisposableTo(self.disposeBag)
+  }
+}


### PR DESCRIPTION
The interactive behavior relies on UIApplication, which is not accessible from extensions. This change allows for projects to import only the non-interactive components to allow for use in extensions. By default, all subspecs in a podspec are used so existing projects will remain unchanged.