### PR TITLE
Fix framework path to be based on build products

### DIFF
--- a/RxKeyboard.xcodeproj/project.pbxproj
+++ b/RxKeyboard.xcodeproj/project.pbxproj
@@ -17,10 +17,10 @@
 		0310C6711DA9525200BDA512 /* RxKeyboard.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RxKeyboard.h; sourceTree = "<group>"; };
 		0310C6731DA9525200BDA512 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		0310C6761DA9535200BDA512 /* RxKeyboard.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RxKeyboard.swift; sourceTree = "<group>"; };
-		034E7CA21DAD548900CFC398 /* RxBlocking.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxBlocking.framework; path = Carthage/Build/iOS/RxBlocking.framework; sourceTree = "<group>"; };
-		034E7CA31DAD548900CFC398 /* RxCocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxCocoa.framework; path = Carthage/Build/iOS/RxCocoa.framework; sourceTree = "<group>"; };
-		034E7CA41DAD548900CFC398 /* RxSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxSwift.framework; path = Carthage/Build/iOS/RxSwift.framework; sourceTree = "<group>"; };
-		034E7CA51DAD548900CFC398 /* RxTests.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxTests.framework; path = Carthage/Build/iOS/RxTests.framework; sourceTree = "<group>"; };
+		034E7CA21DAD548900CFC398 /* RxBlocking.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxBlocking.framework; path = "RxBlocking.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		034E7CA31DAD548900CFC398 /* RxCocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxCocoa.framework; path = "RxCocoa.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		034E7CA41DAD548900CFC398 /* RxSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxSwift.framework; path = "RxSwift.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		034E7CA51DAD548900CFC398 /* RxTests.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxTests.framework; path = "RxTests.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
 		03A258CB1DA94EC50035A85B /* RxKeyboard.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RxKeyboard.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 


### PR DESCRIPTION
One last change to fully building within other workspaces. With this change Xcode can really find the frameworks to cause them to be implicitly built. Before it was working because those files already existed while I was testing the other fix. With a clean build this fixes compilation.