### PR TITLE
Ignore first willShowVisibleHeight event.

### DIFF
--- a/Sources/RxKeyboard.swift
+++ b/Sources/RxKeyboard.swift
@@ -58,6 +58,7 @@ public class RxKeyboard: NSObject {
       }
       .filter { state in state.isShowing }
       .map { state in state.visibleHeight }
+      .skip(1)
     self.isHidden = self.visibleHeight.map({ $0 == 0.0 }).distinctUntilChanged()
     super.init()
 


### PR DESCRIPTION
실제로 키보드를 띄우지 않아도 willShowVisibleHeight를 구독하자 마자 해당 이벤트가 한번 발생합니다.

skip이 아니라 다른 방법을 사용하려고 해보았으나 블루투스 키보드 연결하고 실제로 키보드가 보이지 않는 상태에서 해당 이벤트를 발생시키는 게 쉽지 않네요.