### PR TITLE
Fix Carthage building

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,5 @@
 *.mode1v3
 
 Pods/
-Carthage/
+Carthage/Build
 vendor/


### PR DESCRIPTION
Submodule wasn't checked in, leading to Carthage building not working. .gitignore updated to prevent this issue in the future.

I didn't catch this before since I wasn't using Carthage to build, only manage the dependencies.