### PR TITLE
Updated for Swift 4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode8.3
+osx_image: xcode9.0
 sudo: false
 rvm:
   - 2.3

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "ReactiveX/RxSwift" >= 3.4
+github "ReactiveX/RxSwift" ~> 4.0.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "ReactiveX/RxSwift" "3.4.0"
+github "ReactiveX/RxSwift" "4.0.0-beta.0"

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,17 +1,24 @@
 PODS:
-  - CGFloatLiteral (0.2.0)
+  - CGFloatLiteral (0.3.0)
   - ManualLayout (1.3.0)
-  - ReusableKit (1.1.0)
-  - RxCocoa (3.5.0):
-    - RxSwift (~> 3.4)
-  - RxKeyboard (0.5.0):
+  - ReusableKit (1.3.0):
+    - ReusableKit/Core (= 1.3.0)
+    - ReusableKit/RxSwift (= 1.3.0)
+  - ReusableKit/Core (1.3.0)
+  - ReusableKit/RxSwift (1.3.0):
+    - ReusableKit/Core
     - RxCocoa (>= 3.4)
     - RxSwift (>= 3.4)
-  - RxSwift (3.5.0)
-  - SnapKit (3.1.2)
+  - RxCocoa (4.0.0-beta.0):
+    - RxSwift (~> 4.0.0-beta.0)
+  - RxKeyboard (0.7.0):
+    - RxCocoa (~> 4.0.0-beta.0)
+    - RxSwift (~> 4.0.0-beta.0)
+  - RxSwift (4.0.0-beta.0)
+  - SnapKit (4.0.0)
   - SwiftyColor (1.0.0)
-  - SwiftyImage (1.0.0)
-  - Then (2.1.0)
+  - SwiftyImage (1.2.0)
+  - Then (2.1.1)
   - UITextView+Placeholder (1.2.0)
 
 DEPENDENCIES:
@@ -27,21 +34,21 @@ DEPENDENCIES:
 
 EXTERNAL SOURCES:
   RxKeyboard:
-    :path: "../"
+    :path: ../
 
 SPEC CHECKSUMS:
-  CGFloatLiteral: 5bdcd81cb54b56cd71c4e5e66a33cb86cd51ecbf
+  CGFloatLiteral: faba125ab2bb8fa90142c414f876b83099c26f25
   ManualLayout: 68ac8cfa6b5f656f7a9fadec3730208b95986880
-  ReusableKit: 89e743a120bab0d95848bff27e481833c2768905
-  RxCocoa: a0a09f45d0e5b48ecb6a4a7b4b4c89c88d3f633f
-  RxKeyboard: b360a494f44777cd03f2c09251c50456683ec702
-  RxSwift: 18ee9d78b45edb3b0b7e79916b47a116e6dbc842
-  SnapKit: 12b24f569cb7c143acc9c22b9d91b23e7b1c84a2
+  ReusableKit: 4e4f45128985987555bde17abbf261c0a604f9f2
+  RxCocoa: 8d809675f4e89c5c4c5a6900bbd11fe632ad5d86
+  RxKeyboard: 47be2ee793a7fd39e683b8ac86c610c02f5e49b5
+  RxSwift: e0899fae37065c16db976cc5e3c957e4e388869c
+  SnapKit: a42d492c16e80209130a3379f73596c3454b7694
   SwiftyColor: 7fa09db14051bc5d7f539e1c4576665975225992
-  SwiftyImage: 79090f8b96057b3e91064de172936b97855086e6
-  Then: 8496793c8fcac95482b943909b440724c7d8d82c
+  SwiftyImage: ebaa7c7b6163cd4ad102f3bb05a8fb276d35b4f3
+  Then: 823a7503a851737269ba8d40e688b4db874dbd2d
   UITextView+Placeholder: 77680995fcdd07c3f52ec92fe1150874a2ac89ff
 
 PODFILE CHECKSUM: 49cf5def62bcfa2dfbe0c5118a9372a4162ec992
 
-COCOAPODS: 1.1.1
+COCOAPODS: 1.3.1

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RxKeyboard
 
-![Swift](https://img.shields.io/badge/Swift-3.0-orange.svg)
+![Swift](https://img.shields.io/badge/Swift-4.0-orange.svg)
 [![CocoaPods](http://img.shields.io/cocoapods/v/RxKeyboard.svg)](https://cocoapods.org/pods/RxKeyboard)
 [![Build Status](https://travis-ci.org/RxSwiftCommunity/RxKeyboard.svg?branch=master)](https://travis-ci.org/RxSwiftCommunity/RxKeyboard)
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
@@ -93,12 +93,12 @@ RxKeyboard.instance.frame
     
 ## Dependencies
 
-- [RxSwift](https://github.com/ReactiveX/RxSwift) (>= 3.4)
-- [RxCocoa](https://github.com/ReactiveX/RxSwift) (>= 3.4)
+- [RxSwift](https://github.com/ReactiveX/RxSwift) (~> 4.0.0-beta.0)
+- [RxCocoa](https://github.com/ReactiveX/RxSwift) (~> 4.0.0-beta.0)
 
 ## Requirements
 
-- Swift 3
+- Swift 4
 - iOS 8+
 
 ## Installation

--- a/RxKeyboard.podspec
+++ b/RxKeyboard.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'RxKeyboard'
-  s.version          = '0.6.2'
+  s.version          = '0.7.0'
   s.summary          = 'Reactive Keyboard in iOS'
   s.homepage         = 'https://github.com/RxSwiftCommunity/RxKeyboard'
   s.license          = { :type => 'MIT', :file => 'LICENSE' }
@@ -11,12 +11,12 @@ Pod::Spec.new do |s|
   s.frameworks       = 'UIKit', 'Foundation'
   s.requires_arc     = true
 
-  s.dependency 'RxSwift', '>= 3.4'
-  s.dependency 'RxCocoa', '>= 3.4'
+  s.dependency 'RxSwift', '~> 4.0.0-beta.0'
+  s.dependency 'RxCocoa', '~> 4.0.0-beta.0'
 
   s.ios.deployment_target = '8.0'
 
   s.pod_target_xcconfig = {
-    'SWIFT_VERSION' => '3.1'
+    'SWIFT_VERSION' => '4.0'
   }
 end


### PR DESCRIPTION
Hi, i updated this pod to **Swift 4.0**
**RxKeyboard** works fine like dependency, but **Example** doesn't work, because it has more dependencies, which are not migrated to **Swift 4.0**

[Swift 4.0 issue](https://github.com/RxSwiftCommunity/RxKeyboard/issues/34) - Resolved