### PR TITLE
📝 Fix contentOffset example

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ RxKeyboard.instance.frame
     ```swift
     RxKeyboard.instance.willShowVisibleHeight
       .drive(onNext: { keyboardVisibleHeight in
-        scrollView.contentInset.offset.y += keyboardVisibleHeight
+        scrollView.contentOffset.y += keyboardVisibleHeight
       })
       .disposed(by: disposeBag)
     ```


### PR DESCRIPTION
Updates readme's `contentOffset` example to match UIKit's API