### PR TITLE
Use bind(to:) on BehaviorReplay

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -9,12 +9,12 @@ PODS:
     - ReusableKit/Core
     - RxCocoa (>= 3.4)
     - RxSwift (>= 3.4)
-  - RxCocoa (4.0.0-beta.0):
-    - RxSwift (~> 4.0.0-beta.0)
-  - RxKeyboard (0.7.0):
-    - RxCocoa (~> 4.0.0-beta.0)
-    - RxSwift (~> 4.0.0-beta.0)
-  - RxSwift (4.0.0-beta.0)
+  - RxCocoa (4.1.2):
+    - RxSwift (~> 4.0)
+  - RxKeyboard (0.8.1):
+    - RxCocoa (>= 4.0.0)
+    - RxSwift (>= 4.0.0)
+  - RxSwift (4.1.2)
   - SnapKit (4.0.0)
   - SwiftyColor (1.0.0)
   - SwiftyImage (1.2.0)
@@ -40,9 +40,9 @@ SPEC CHECKSUMS:
   CGFloatLiteral: 2ab558b74124b584dd023a35b7e41795a61d8140
   ManualLayout: 68ac8cfa6b5f656f7a9fadec3730208b95986880
   ReusableKit: 4e4f45128985987555bde17abbf261c0a604f9f2
-  RxCocoa: 8d809675f4e89c5c4c5a6900bbd11fe632ad5d86
-  RxKeyboard: 4167b1f005745a4178c3ac4adfc8177482b87675
-  RxSwift: e0899fae37065c16db976cc5e3c957e4e388869c
+  RxCocoa: d88ba0f1f6abf040011a9eb4b539324fc426843a
+  RxKeyboard: ce24525d4a3dc983664e44540f240c8e7bb4d4b8
+  RxSwift: e49536837d9901277638493ea537394d4b55f570
   SnapKit: a42d492c16e80209130a3379f73596c3454b7694
   SwiftyColor: 7fa09db14051bc5d7f539e1c4576665975225992
   SwiftyImage: ebaa7c7b6163cd4ad102f3bb05a8fb276d35b4f3

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/ReactiveX/RxSwift.git",
         "state": {
           "branch": null,
-          "revision": "12cccb171ad9038251af6883807f0290c1d75a5b",
-          "version": "4.0.0"
+          "revision": "3e848781c7756accced855a6317a4c2ff5e8588b",
+          "version": "4.1.2"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
     .library(name: "RxKeyboard", targets: ["RxKeyboard"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/ReactiveX/RxSwift.git", .upToNextMajor(from: "4.0.0")),
+    .package(url: "https://github.com/ReactiveX/RxSwift.git", .upToNextMajor(from: "4.1.0")),
   ],
   targets: [
     .target(name: "RxKeyboard", dependencies: ["RxSwift", "RxCocoa"]),

--- a/Sources/RxKeyboard/RxKeyboard.swift
+++ b/Sources/RxKeyboard/RxKeyboard.swift
@@ -115,10 +115,8 @@ public class RxKeyboard: NSObject, RxKeyboardType {
 
     // merge into single sequence
     Observable.of(didPan, willChangeFrame, willHide).merge()
-        .subscribe(onNext: { [weak frameVariable] frame in
-            frameVariable?.accept(frame)
-        })
-        .disposed(by: self.disposeBag)
+      .bind(to: frameVariable)
+      .disposed(by: self.disposeBag)
 
     // gesture recognizer
     self.panRecognizer.delegate = self


### PR DESCRIPTION
* It fixes #58
* `bind(to:)` on `BehaviorReplay` is introduced in RxSwift 4.1.0 so this PR also includes a RxSwift version bumping commit.
