### PR TITLE
rxKeyboard: use private access modifier when needed

### DIFF
--- a/Sources/RxKeyboard/RxKeyboard.swift
+++ b/Sources/RxKeyboard/RxKeyboard.swift
@@ -44,8 +44,8 @@ public class RxKeyboard: NSObject, RxKeyboardType {
 
   // MARK: Private
 
-  fileprivate let disposeBag = DisposeBag()
-  fileprivate let panRecognizer = UIPanGestureRecognizer()
+  private let disposeBag = DisposeBag()
+  private let panRecognizer = UIPanGestureRecognizer()
 
 
   // MARK: Initializing


### PR DESCRIPTION
Hi!

This commit replaces the `fileprivate` access modifiers by `private`
when it is needed.

Thanks!