### PR TITLE
Update RxSwift dependency to 4.1.0.

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "ReactiveX/RxSwift" ~> 4.0.0
+github "ReactiveX/RxSwift" ~> 4.1.0

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -11,9 +11,9 @@ PODS:
     - RxSwift (>= 3.4)
   - RxCocoa (4.1.2):
     - RxSwift (~> 4.0)
-  - RxKeyboard (0.8.1):
-    - RxCocoa (>= 4.0.0)
-    - RxSwift (>= 4.0.0)
+  - RxKeyboard (0.8.2):
+    - RxCocoa (>= 4.1.0)
+    - RxSwift (>= 4.1.0)
   - RxSwift (4.1.2)
   - SnapKit (4.0.0)
   - SwiftyColor (1.0.0)
@@ -41,7 +41,7 @@ SPEC CHECKSUMS:
   ManualLayout: 68ac8cfa6b5f656f7a9fadec3730208b95986880
   ReusableKit: 4e4f45128985987555bde17abbf261c0a604f9f2
   RxCocoa: d88ba0f1f6abf040011a9eb4b539324fc426843a
-  RxKeyboard: ce24525d4a3dc983664e44540f240c8e7bb4d4b8
+  RxKeyboard: 24d6d56cda6f95519533f063af94b6e67bed64e4
   RxSwift: e49536837d9901277638493ea537394d4b55f570
   SnapKit: a42d492c16e80209130a3379f73596c3454b7694
   SwiftyColor: 7fa09db14051bc5d7f539e1c4576665975225992

--- a/README.md
+++ b/README.md
@@ -93,8 +93,8 @@ RxKeyboard.instance.frame
     
 ## Dependencies
 
-- [RxSwift](https://github.com/ReactiveX/RxSwift) (>= 4.0.0)
-- [RxCocoa](https://github.com/ReactiveX/RxSwift) (>= 4.0.0)
+- [RxSwift](https://github.com/ReactiveX/RxSwift) (>= 4.1.0)
+- [RxCocoa](https://github.com/ReactiveX/RxSwift) (>= 4.1.0)
 
 ## Requirements
 

--- a/RxKeyboard.podspec
+++ b/RxKeyboard.podspec
@@ -11,8 +11,8 @@ Pod::Spec.new do |s|
   s.frameworks       = 'UIKit', 'Foundation'
   s.requires_arc     = true
 
-  s.dependency 'RxSwift', '>= 4.0.0'
-  s.dependency 'RxCocoa', '>= 4.0.0'
+  s.dependency 'RxSwift', '>= 4.1.0'
+  s.dependency 'RxCocoa', '>= 4.1.0'
 
   s.ios.deployment_target = '8.0'
 end


### PR DESCRIPTION
#59 bumped the SPM RxSwift dependency to 4.1.0, but Carthage and Cocoapods were left as 4.0.0. 