### PR TITLE
Fixed protection level of pan recognizer

### DIFF
--- a/Sources/RxKeyboard/RxKeyboard.swift
+++ b/Sources/RxKeyboard/RxKeyboard.swift
@@ -42,10 +42,10 @@ public class RxKeyboard: NSObject, RxKeyboardType {
   /// when changed keyboard show and hide.
   public let isHidden: Driver<Bool>
 
-  // MARK: Private
+  public let panRecognizer = UIPanGestureRecognizer()
 
+  // MARK: Private
   private let disposeBag = DisposeBag()
-  private let panRecognizer = UIPanGestureRecognizer()
 
 
   // MARK: Initializing


### PR DESCRIPTION
Resolves Xcode 9.4.1 / Swift 4.1 protection level compile error. 