### PR TITLE
Update RxSwift dependency to 4.4.0

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "ReactiveX/RxSwift" ~> 4.3.1
+github "ReactiveX/RxSwift" ~> 4.4.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "ReactiveX/RxSwift" "4.3.1"
+github "ReactiveX/RxSwift" "4.4.0"

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,20 +1,22 @@
 PODS:
   - CGFloatLiteral (0.4.0)
   - ManualLayout (1.3.0)
-  - ReusableKit (2.0.1):
-    - ReusableKit/Core (= 2.0.1)
-  - ReusableKit/Core (2.0.1)
-  - RxCocoa (4.3.1):
+  - ReusableKit (2.1.0):
+    - ReusableKit/Core (= 2.1.0)
+  - ReusableKit/Core (2.1.0)
+  - RxAtomic (4.4.0)
+  - RxCocoa (4.4.0):
     - RxSwift (~> 4.0)
-  - RxKeyboard (0.8.3):
-    - RxCocoa (>= 4.3.0)
-    - RxSwift (>= 4.3.0)
-  - RxSwift (4.3.1)
-  - SnapKit (4.0.1)
-  - SwiftyColor (1.0.0)
-  - SwiftyImage (1.2.0)
-  - Then (2.3.0)
-  - UITextView+Placeholder (1.2.1)
+  - RxKeyboard (0.9.1):
+    - RxCocoa (>= 4.4.0)
+    - RxSwift (>= 4.4.0)
+  - RxSwift (4.4.0):
+    - RxAtomic (~> 4.4)
+  - SnapKit (4.2.0)
+  - SwiftyColor (1.1.0)
+  - SwiftyImage (1.3.0)
+  - Then (2.4.0)
+  - "UITextView+Placeholder (1.2.1)"
 
 DEPENDENCIES:
   - CGFloatLiteral
@@ -25,25 +27,40 @@ DEPENDENCIES:
   - SwiftyColor
   - SwiftyImage
   - Then
-  - UITextView+Placeholder
+  - "UITextView+Placeholder"
+
+SPEC REPOS:
+  https://github.com/cocoapods/specs.git:
+    - CGFloatLiteral
+    - ManualLayout
+    - ReusableKit
+    - RxAtomic
+    - RxCocoa
+    - RxSwift
+    - SnapKit
+    - SwiftyColor
+    - SwiftyImage
+    - Then
+    - "UITextView+Placeholder"
 
 EXTERNAL SOURCES:
   RxKeyboard:
-    :path: ../
+    :path: "../"
 
 SPEC CHECKSUMS:
   CGFloatLiteral: 2ab558b74124b584dd023a35b7e41795a61d8140
   ManualLayout: 68ac8cfa6b5f656f7a9fadec3730208b95986880
-  ReusableKit: 11b5bde14553a35bcf3979412dbfd1e690392f14
-  RxCocoa: 78763c7b07d02455598d9fc3c1ad091a28b73635
-  RxKeyboard: cdc73085509a6baa5795038372d86260bb683bed
-  RxSwift: fe0fd770a43acdb7d0a53da411c9b892e69bb6e4
-  SnapKit: 0de968a9fec17499afa29683b05d0c775b6d1c29
-  SwiftyColor: 7fa09db14051bc5d7f539e1c4576665975225992
-  SwiftyImage: ebaa7c7b6163cd4ad102f3bb05a8fb276d35b4f3
-  Then: ee21c97b85ff6062b9b0080c9abb1eea46743345
-  UITextView+Placeholder: 0c3efd97f37ea64bde7f34cc6e90fe02e87b3909
+  ReusableKit: d0b040de03b293288b0ca27a78602691d3346d9b
+  RxAtomic: eacf60db868c96bfd63320e28619fe29c179656f
+  RxCocoa: df63ebf7b9a70d6b4eeea407ed5dd4efc8979749
+  RxKeyboard: 298b7ee53e4f54853dff304eb516ba560d9dbefc
+  RxSwift: 5976ecd04fc2fefd648827c23de5e11157faa973
+  SnapKit: fe8a619752f3f27075cc9a90244d75c6c3f27e2a
+  SwiftyColor: f2955e3a947f4faef07162a289d326ba0662d667
+  SwiftyImage: 62a73a6d8cafb83d7ebbf98795c6d1ad8666bf02
+  Then: 71866660c7af35a7343831f7668e7cd2b62ee0f2
+  "UITextView+Placeholder": 0c3efd97f37ea64bde7f34cc6e90fe02e87b3909
 
 PODFILE CHECKSUM: 49cf5def62bcfa2dfbe0c5118a9372a4162ec992
 
-COCOAPODS: 1.3.1
+COCOAPODS: 1.5.3

--- a/Example/RxKeyboardExample.xcodeproj/project.pbxproj
+++ b/Example/RxKeyboardExample.xcodeproj/project.pbxproj
@@ -149,7 +149,6 @@
 				03E8A71B1E35A95B00F7A3EC /* Frameworks */,
 				03E8A71C1E35A95B00F7A3EC /* Resources */,
 				E857CEA8F03D723AC93BD7A1 /* [CP] Embed Pods Frameworks */,
-				2D555D8C90E50248DB41694D /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -207,21 +206,6 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		2D555D8C90E50248DB41694D /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-RxKeyboardExample/Pods-RxKeyboardExample-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		D103E37D22DD7DDCE369FBBB /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -250,6 +234,7 @@
 				"${BUILT_PRODUCTS_DIR}/CGFloatLiteral/CGFloatLiteral.framework",
 				"${BUILT_PRODUCTS_DIR}/ManualLayout/ManualLayout.framework",
 				"${BUILT_PRODUCTS_DIR}/ReusableKit/ReusableKit.framework",
+				"${BUILT_PRODUCTS_DIR}/RxAtomic/RxAtomic.framework",
 				"${BUILT_PRODUCTS_DIR}/RxCocoa/RxCocoa.framework",
 				"${BUILT_PRODUCTS_DIR}/RxKeyboard/RxKeyboard.framework",
 				"${BUILT_PRODUCTS_DIR}/RxSwift/RxSwift.framework",
@@ -264,6 +249,7 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/CGFloatLiteral.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ManualLayout.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ReusableKit.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RxAtomic.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RxCocoa.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RxKeyboard.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RxSwift.framework",

--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
     .library(name: "RxKeyboard", targets: ["RxKeyboard"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/ReactiveX/RxSwift.git", .upToNextMajor(from: "4.3.0")),
+    .package(url: "https://github.com/ReactiveX/RxSwift.git", .upToNextMajor(from: "4.4.0")),
   ],
   targets: [
     .target(name: "RxKeyboard", dependencies: ["RxSwift", "RxCocoa"]),

--- a/README.md
+++ b/README.md
@@ -93,8 +93,8 @@ RxKeyboard.instance.frame
     
 ## Dependencies
 
-- [RxSwift](https://github.com/ReactiveX/RxSwift) (>= 4.1.0)
-- [RxCocoa](https://github.com/ReactiveX/RxSwift) (>= 4.1.0)
+- [RxSwift](https://github.com/ReactiveX/RxSwift) (>= 4.4.0)
+- [RxCocoa](https://github.com/ReactiveX/RxSwift) (>= 4.4.0)
 
 ## Requirements
 

--- a/RxKeyboard.podspec
+++ b/RxKeyboard.podspec
@@ -11,8 +11,8 @@ Pod::Spec.new do |s|
   s.frameworks       = 'UIKit', 'Foundation'
   s.requires_arc     = true
 
-  s.dependency 'RxSwift', '>= 4.3.1'
-  s.dependency 'RxCocoa', '>= 4.3.1'
+  s.dependency 'RxSwift', '>= 4.4.0'
+  s.dependency 'RxCocoa', '>= 4.4.0'
 
   s.ios.deployment_target = '8.0'
 end


### PR DESCRIPTION
It was unable to use RxKeyboard by upgrading RxSwift 4.4.0 version recently.
cf: https://github.com/ReactiveX/RxSwift/releases/tag/4.4.0

I bumped up RxSwift version to 4.4.0 👍 