### PR TITLE
CGFloat comparison issue

### DIFF
--- a/Sources/RxKeyboard/RxKeyboard.swift
+++ b/Sources/RxKeyboard/RxKeyboard.swift
@@ -77,7 +77,7 @@ public class RxKeyboard: NSObject, RxKeyboardType {
       }
       .filter { state in state.isShowing }
       .map { state in state.visibleHeight }
-    self.isHidden = self.visibleHeight.map({ $0 == 0.0 }).distinctUntilChanged()
+    self.isHidden = self.visibleHeight.map({ $0 <= .ulpOfOne }).distinctUntilChanged()
     super.init()
 
     // keyboard will change frame


### PR DESCRIPTION
I've realised that on iPhone XS Max you can get >0 height of the hidden keyboard. So better compare keyboard height with epsilon nether than 0