### PR TITLE
The visibleHeight's output is wrong when 'Reduce Motion' and 'Prefer Cross-Fade Transitions' are on.

### DIFF
--- a/Sources/RxKeyboard/RxKeyboard.swift
+++ b/Sources/RxKeyboard/RxKeyboard.swift
@@ -63,7 +63,7 @@ public class RxKeyboard: NSObject, RxKeyboardType {
     )
     let frameVariable = BehaviorRelay<CGRect>(value: defaultFrame)
     self.frame = frameVariable.asDriver().distinctUntilChanged()
-    self.visibleHeight = self.frame.map { UIScreen.main.bounds.height - $0.origin.y }
+    self.visibleHeight = self.frame.map { UIScreen.main.bounds.intersection($0).height }
     self.willShowVisibleHeight = self.visibleHeight
       .scan((visibleHeight: 0, isShowing: false)) { lastState, newVisibleHeight in
         return (visibleHeight: newVisibleHeight, isShowing: lastState.visibleHeight == 0 && newVisibleHeight > 0)


### PR DESCRIPTION
First, turn on 'ReduceMotion' and 'Prefer Cross-FadeTransitions'. (Settings > Accessibility > Motion > ReduceMotion and Prefer Cross-Fade Transitions)
And make a view controller containing UITableView like below.
```swift
import UIKit
import SnapKit
import RxKeyboard
import RxSwift

class TableViewCell: UITableViewCell {
}

class ViewController: UIViewController {

    private let textField = UITextField()
    private let tableView = UITableView()
    private let disposeBag = DisposeBag()

    override func viewDidLoad() {
        super.viewDidLoad()
        initialize()

        RxKeyboard.instance.frame
            .drive(onNext: { frame in
                print("## frame \(frame)")
                // Result when the keyboard appeared: ## frame (0.0, 521.0, 375.0, 291.0)
                // Result when the keyboard disappeared: ## frame (0.0, 812.0, 375.0, 71.0)
            })
            .disposed(by: disposeBag)

        RxKeyboard.instance.visibleHeight
            .drive(onNext: { frame in
                print("## visibleHeight \(frame)")
                // Result when the keyboard appeared: ## visibleHeight 291.0
                // Result when the keyboard disappeared: ## visibleHeight 0.0 and -71.0 (print twice)
            })
            .disposed(by: disposeBag)
    }

    private func initialize() {
        tableView.delegate = self
        tableView.dataSource = self
        tableView.register(TableViewCell.self, forCellReuseIdentifier: "TableViewCell")
        tableView.keyboardDismissMode = .onDrag
        view.addSubview(textField)
        view.addSubview(tableView)

        textField.snp.makeConstraints { make in
            make.top.equalToSuperview().offset(50)
            make.leading.trailing.equalToSuperview().inset(25)
            make.height.equalTo(50)
        }
        tableView.snp.makeConstraints { make in
            make.top.equalTo(textField.snp.bottom)
            make.leading.bottom.trailing.equalToSuperview()
        }
    }
}

```
The RxKeyboard.frame output is (0.0, 812.0, 375.0, 291.0) when the keyboard is visible.
But after the keyboard dismiss, the RxKeyboard.frame is (0.0, 812.0, 375.0, 71.0)
So RxKeyboard.visibleHeight returns -71.
I use the `CGRect.intersection` function instead of subtracting origin.y for calculating visible height.