### PR TITLE
maximumNumberOfTouches of panRecognizer restricted to 1

### DIFF
--- a/Sources/RxKeyboard/RxKeyboard.swift
+++ b/Sources/RxKeyboard/RxKeyboard.swift
@@ -124,7 +124,7 @@ public class RxKeyboard: NSObject, RxKeyboardType {
 
     // gesture recognizer
     self.panRecognizer.delegate = self
-    
+    self.panRecognizer.maximumNumberOfTouches = 1
     UIApplication.rx.didFinishLaunching // when RxKeyboard is initialized before UIApplication.window is created
       .subscribe(onNext: { _ in
         UIApplication.shared.windows.first?.addGestureRecognizer(self.panRecognizer)

--- a/Sources/RxKeyboard/RxKeyboard.swift
+++ b/Sources/RxKeyboard/RxKeyboard.swift
@@ -125,6 +125,7 @@ public class RxKeyboard: NSObject, RxKeyboardType {
     // gesture recognizer
     self.panRecognizer.delegate = self
     self.panRecognizer.maximumNumberOfTouches = 1
+    
     UIApplication.rx.didFinishLaunching // when RxKeyboard is initialized before UIApplication.window is created
       .subscribe(onNext: { _ in
         UIApplication.shared.windows.first?.addGestureRecognizer(self.panRecognizer)


### PR DESCRIPTION
If you dismiss keyboard by one finger and the second one place on the scrollView while the keyboard on the half way to the bottom RxKeyboard.instance.visibleHeight observable reacts to both fingers simultaneously, that leads to separating message bar from the keyboard. You can try it even with applied Example app.
This fix addresses the issue and we have behavior similar to native message app, please check it.
Thanks